### PR TITLE
Encryption & notary differences from Matrix.

### DIFF
--- a/mx-differences.md
+++ b/mx-differences.md
@@ -216,23 +216,6 @@ The only change is made to Step 1 of the content hashing algorithm. The full alg
 3. Hash the resulting bytes with SHA-256.
 4. Encode the hash using unpadded base64.
 
-## Request Authentication
-
-There are largely clarifications to how request authentication works. Namely:
-
-* A 401 M_FORBIDDEN error is returned when improperly authenticated.
-* Only one of the sender's signing keys needs to be used, but senders should send as many as possible (if the server
-  has multiple signing keys).
-* A failure in any one `Authorization` header is treated as fatal for the whole request.
-* `GET` requests, or those without a request body, are represented as `{}` in the signed JSON.
-* `destination` in the `Authorization` header is formally required, though backwards compatible with Matrix today.
-
-This is meant to be compatible with [MSC4029](https://github.com/matrix-org/matrix-spec-proposals/pull/4029), when
-MSC4029 has real content in it.
-
-Linearized Matrix requires attempting the server *first* before falling back to
-a notary server.
-
 ### Encryption
 
 Encryption is enabled via an `encryption` property in the `m.room.create` event, not via a separate
@@ -252,6 +235,23 @@ Thus encryption must be enabled at room creation time.
 `m.mls.commit` events can be viewed by any user in the room, regardless of
 history visibility. (Does this mean `shared` or `world_readable` or something
 else? Can a user see them after they've left? How does this work?)
+
+## Request Authentication
+
+There are largely clarifications to how request authentication works. Namely:
+
+* A 401 M_FORBIDDEN error is returned when improperly authenticated.
+* Only one of the sender's signing keys needs to be used, but senders should send as many as possible (if the server
+  has multiple signing keys).
+* A failure in any one `Authorization` header is treated as fatal for the whole request.
+* `GET` requests, or those without a request body, are represented as `{}` in the signed JSON.
+* `destination` in the `Authorization` header is formally required, though backwards compatible with Matrix today.
+
+This is meant to be compatible with [MSC4029](https://github.com/matrix-org/matrix-spec-proposals/pull/4029), when
+MSC4029 has real content in it.
+
+Linearized Matrix requires attempting the server *first* before falling back to
+a notary server.
 
 ## Linearization Algorithm
 

--- a/mx-differences.md
+++ b/mx-differences.md
@@ -233,8 +233,8 @@ Encryption is enabled via an `encryption` property in the `m.room.create` event,
 Thus encryption must be enabled at room creation time.
 
 `m.mls.commit` events can be viewed by any user in the room, regardless of
-history visibility. (Does this mean `shared` or `world_readable` or something
-else? Can a user see them after they've left? How does this work?)
+history visibility. The draft doesn't currently cover how exactly this works,
+but should be treated as `shared` history for ease of use for now.
 
 ## Request Authentication
 

--- a/mx-differences.md
+++ b/mx-differences.md
@@ -230,6 +230,29 @@ There are largely clarifications to how request authentication works. Namely:
 This is meant to be compatible with [MSC4029](https://github.com/matrix-org/matrix-spec-proposals/pull/4029), when
 MSC4029 has real content in it.
 
+Linearized Matrix requires attempting the server *first* before falling back to
+a notary server.
+
+### Encryption
+
+Encryption is enabled via an `encryption` property in the `m.room.create` event, not via a separate
+`m.room.encryption` event:
+
+
+```json
+{
+   "encryption": {
+      "algorithm": "m.mls.v1.dhkemx25519-aes128gcm-sha256-ed25519"
+   }
+}
+```
+
+Thus encryption must be enabled at room creation time.
+
+`m.mls.commit` events can be viewed by any user in the room, regardless of
+history visibility. (Does this mean `shared` or `world_readable` or something
+else? Can a user see them after they've left? How does this work?)
+
 ## Linearization Algorithm
 
 The specific mechanics of this algorithm are undefined. The rough idea is that when a DAG-capable server becomes


### PR DESCRIPTION
I'm unsure if either of these are worth calling out:

* I don't think servers care much about encryption -- the auth rules don't touch the `m.room.encryption` event
* The notary difference may not matter much, but [Synapse checks the local cache, then notaries, then directly fetches](https://github.com/matrix-org/synapse/blob/b516d919995f3bf36045263376628ff0aa298095/synapse/crypto/keyring.py#L154-L161).